### PR TITLE
Fix splitter set size

### DIFF
--- a/gui/MainWindow.py
+++ b/gui/MainWindow.py
@@ -38,7 +38,11 @@ class MainWindow(QMainWindow):
         self.ui.graphWidget.ci.layout.setSpacing(20)
 
         width = QApplication.primaryScreen().size().width()
-        self.ui.splitterHorizontal.setSizes([width/8, width*5/8, width*2/8])
+        
+        w_8 = int(width/8)
+        w_5_8 = int(width*5/8)
+        w_2_8 = int(width*2/8)
+        self.ui.splitterHorizontal.setSizes([w_8, w_5_8 ,w_2_8 ])
 
     def on_buttonClearLog_clicked(self):
         self.ui.teLog.clear()

--- a/gui/MainWindow.py
+++ b/gui/MainWindow.py
@@ -39,6 +39,7 @@ class MainWindow(QMainWindow):
 
         width = QApplication.primaryScreen().size().width()
         
+        # set splitter sizes from left to right
         w_8 = int(width/8)
         w_5_8 = int(width*5/8)
         w_2_8 = int(width*2/8)


### PR DESCRIPTION
Hi PoliTOcean team

I've just tried to clone your GUI for the sake of curiosity and I've noticed that following the readme page the program does not run due to a simple type error.
```
File "/home/nicola/dev/EVA/gui/MainWindow.py", line 41, in __init__
    self.ui.splitterHorizontal.setSizes([width/8, width*5/8, width*2/8])
TypeError: index 0 has type 'float' but 'int' is expected
```
so I created 3 integer variables `w_8` `w_5_8` and `w_2_8`.