### PR TITLE
Add how to enable virtual environment

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -4,16 +4,29 @@ The GUI is a remake in Python of the project [Monterey](https://github.com/rovsu
 
 ## Setting up the environment
 
-Create a new virtual environment running
+1. Create a new virtual environment running
+    ```bash
+    python3 -m venv env
+    ```
 
-```bash
-python3 -m venv env
+2. Activate the virtual environment systems via
+      ```bash
+      source ./env/bin/activate
+      ```
+    It can beand deactivated typing `deactivate`.
+
+    On Windows system there is a dedicated script as well to enable and disable the environment in `./env/bin`.
+
+
+3. Install all the required dependencies using PiP run
+
+    ```bash
+    ./env/bin/python3 -m pip install -r requirements.txt
+    ```
+
+We do recomend to **locally** ignore such folder adding in `.git/info/exclude` the following line
 ```
-
-To install all the required dependencies using PiP run
-
-```bash
-python3 -m pip install -r requirements.txt
+**/env
 ```
 
 Your environment is set up.


### PR DESCRIPTION
I've added some lines on the README file regarding how to start the virtual environment on the terminal. It could seem straightforward for the majority of the audience but not for newcomers.

I've also included the `env` folder into the local `exclude` file, positioned in `.git/info/exclude`.
I do believe that is better to exclude it locally, and not in the usual `.gitignore` file for two reasons:

* The file is generated by the developer and someone could decide to do not to use a virtual environment at all.
* Is not so common to use the local exclude file. Someone could learn something new thanks to this README line 😄.